### PR TITLE
Shorten some length prefixes

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -344,13 +344,13 @@ enum {
 
 struct {
     ClaimType claim_type;
-    opaque claim_info<0..2^24-1>;
+    opaque claim_info<0..2^16-1>;
 } Claim;
 
 struct {
     SubjectType subject_type;
-    opaque subject_info<0..2^24-1>;
-    Claim claims<0..2^24-1>;
+    opaque subject_info<0..2^16-1>;
+    Claim claims<0..2^16-1>;
 } Assertion;
 ~~~
 
@@ -359,7 +359,7 @@ An Assertion is roughly analogous to an X.509 TBSCertificate ({{Section 4.1.2 of
 ~~~
 struct {
     SignatureScheme signature;
-    opaque public_key<1..2^24-1>;
+    opaque public_key<1..2^16-1>;
 } TLSSubjectInfo;
 ~~~
 
@@ -890,7 +890,7 @@ enum { tls(0), (2^16-1) } SubjectType;
 
 struct {
     SignatureScheme signature;
-    opaque public_key<1..2^24-1>;
+    opaque public_key<1..2^16-1>;
     /* TODO: Should there be an extension list? */
 } TLSSubjectInfo;
 ~~~


### PR DESCRIPTION
Feedback from Ilari Liusvaara on the list. I picked the lengths mostly arbitrarily. This shaves a few bytes, though it does introduce some length limits over X.509 in TLS today. (TLS uses 2^24-1 for the overall certificate structure. Within a certificate, DER gives variable-length lengths.)