### PR TITLE
Rebase the draft on top of draft-beck-tls-trust-anchor-ids

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -639,6 +639,9 @@ A CA MUST NOT generate signatures over inputs that are parseable as LabeledValid
 For each assertion in the tree, the CA constructs a BikeshedCertificate structure containing the assertion and a proof. A proof is a message that allows the relying party to accept the associated assertion, provided it trusts the CA and recognizes the tree head. The structures are defined below:
 
 ~~~
+/* See Section 4.1 of draft-beck-tls-trust-anchor-ids */
+opaque TrustAnchorIdentifier<1..2^8-1>;
+
 struct {
     TrustAnchorIdentifier trust_anchor;
     opaque proof_data<0..2^16-1>;

--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -634,7 +634,7 @@ A CA MUST NOT generate signatures over inputs that are parseable as LabeledValid
 
 [[TODO: BikeshedCertificate is a placeholder name until someone comes up with a better one. #15 ]]
 
-[[TODO: A subscriber has no way to know when a certificate expires. See #83, which avoids defining an expiration time certificate property.]]
+[[TODO: A subscriber has no way to know when a certificate expires. We need to define a mandatory expiration certificate property, or do #83, which, depending on how it's done could avoid that.]]
 
 For each assertion in the tree, the CA constructs a BikeshedCertificate structure containing the assertion and a proof. A proof is a message that allows the relying party to accept the associated assertion, provided it trusts the CA and recognizes the tree head. The structures are defined below:
 


### PR DESCRIPTION
The main changes:

* ProofType is gone and now implicit from the trust anchor

* TrustAnchor is gone and replaced with TrustAnchorIdentifier from draft-beck-tls-trust-anchor-ids.

* The negotiation mechanism is removed and instead references draft-beck-tls-trust-anchor-ids, adding some guidance on how to use it.

* We did lose the aliases mechanism and instead take a harder dependency on the DNS mechanism in draft-beck-tls-trust-anchor-ids. I've filed https://github.com/davidben/tls-trust-expressions/issues/62 to track restoring that.

* General discussion on agility is removed as draft-beck-tls-trust-anchor-ids covers that.

* Just to get it out of the way, I moved the discussion on client certificate types to an appendix.

Fixes #80