### PR TITLE
Use `<1..2^24-1>` encoding for all certificate types

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -941,7 +941,7 @@ struct {
     select (certificate_type) {
         /* Certificate type defined in this document */
         case Bikeshed:
-            BikeshedCertificate certificate;
+            opaque bikeshed_cert_data<1..2^24-1>;
 
         /* From RFC 7250 */
         case RawPublicKey:


### PR DESCRIPTION
In favor of an easier implementation, I propose to change the `CertificateEntry` TLS message such that the Bikeshed certificate is embedded in a length prefixed array. It makes parsing the packets sent over the wire agnostic to the negotiated certificate type. The interpretation/parsing can thus be postponed to checking the certificate.
As the side effect, it is halfway to the solution for negotiating client certificate types as discussed in [Section B.1](https://datatracker.ietf.org/doc/html/draft-davidben-tls-merkle-tree-certs-03#appendix-B.1).