### PR TITLE
Rework discussion of the transparency ecosystem

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -807,7 +807,7 @@ Transparency:
 
 How the relying party does this has no direct impact on certificate issuance ({{issuing-certificates}}) or usage ({{using}}). Different relying parties can obtain validity windows from different sources or apply different policies, while supporting the same unmodified certificates and CAs. Thus this section does not prescribe particular policies or mechanisms, but provides examples and general guidance. Relying parties MAY implement policies other than those described below, and MAY incorporate entities acting in roles not described in this document.
 
-Relying parties SHOULD ensure transparency by obtaining validity windows from the CA and/or some combination of trusted mirrors. The relying party picks sources which, together, are trusted to satisfy the requirements described in {{mirrors}}. Mirrors allow the relying party to maintain transparency in the face of a misbehaving CA that may, for example, stop serving some unauthorized certificate in a batch to evade detection.
+Relying parties SHOULD ensure transparency by obtaining validity windows from the CA and/or some combination of trusted mirrors. The relying party picks sources which, together, are trusted to satisfy the requirements described in {{mirrors}}. Mirrors allow the relying party to maintain transparency in the face of a misbehaving or compromised CA that may, for example, stop serving some unauthorized certificate in a batch to evade detection.
 
 A relying party might trust a combination of mirrors, and only accept a validity window once some minimum number of mirrors have consumed it. When combining multiple mirrors, the following procedure determines the latest validity window for an update:
 


### PR DESCRIPTION
Although the transparency service was clearly described throughout the document as an abstraction and not actually necessarily one single centralized service, this seems to have been a point of confusion. The intent was to observe that this system actually allows the ecosystem to freely design trust models, mirroring roles, etc., all without impact to interoperability. As this all happens out of band, neither certificate issuance nor certificate usage is impacted by these choices, except that a certificate may or may not be selected by negotiation.

This seems to have been a confusing notion. To avoid that mess, recut these concepts in the document.

First, define the role of a mirror as a concrete service with some responsibility. This picks up the mirroring aspects of the old example transparency services, but not the direct connection to an RP or trustworthiness. It's a freefloating service with some responsibility. You may or may not believe it meets those responsibilities.

Then, define a relying party policy, for how an RP gets gets validity windows. This is more explicitly the source of implementation dependence. RPs can choose to trust some combination of mirrors when formulating this policy. We give several example policies, but don't mandate anything in particular.

Rewrite the rest of this text according to this framing.

Closes #99.