### PR TITLE
Program in English as well as Python

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -467,7 +467,7 @@ def find_subtrees(start, end):
     """ Returns a list of one or two subtrees that efficiently
     cover [start, end). """
     assert start < end
-    if end - start < 2:
+    if end - start == 1:
         return [(start, end),]
     last = end - 1
     # Find where start and last's tree paths diverge. The two


### PR DESCRIPTION
This adds a prose version of the "Arbitrary Intervals" procedure. The Python one is clearer I think, but IETF does like to program in English.

I've renamed `left` to `left_start` in some places so we don't have two things called `left`.

(Also adding @lukevalenta who I cannot set as reviewer yet because apparently I forgot to add you to the repo! 😳)