### PR TITLE
Use ceil+1 instead of ceil to calculate max_landmarks

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -880,7 +880,7 @@ The most recent `max_landmarks` landmarks are said to be *active*. Landmarks MUS
 
 If landmarks are allocated incorrectly (e.g. past landmarks change, or `max_landmarks` is inaccurate), there are no security consequences, but some older certificates may fail to validate.
 
-It is RECOMMENDED that landmarks be allocated by picking some `time_between_landmarks` interval, and then appending the latest checkpoint tree size to the sequence, once per interval. If the latest checkpoint tree size is already a landmark, the interval is skipped. `max_landmarks` can then be set to `ceil(max_cert_lifetime / time_between_landmarks)`, where `max_cert_lifetime` is the CA's maximum certificate lifetime. Allocations do not need to be precise, as long as `max_landmarks` is accurate.
+It is RECOMMENDED that landmarks be allocated by picking some `time_between_landmarks` interval, and then appending the latest checkpoint tree size to the sequence, once per interval. If the latest checkpoint tree size is already a landmark, the interval is skipped. `max_landmarks` can then be set to `ceil(max_cert_lifetime / time_between_landmarks) + 1`, where `max_cert_lifetime` is the CA's maximum certificate lifetime. Allocations do not need to be precise, as long as `max_landmarks` is accurate.
 
 Relying parties will locally retain up to `2 * max_landmarks` hashes ({{trusted-subtrees}}) per CA, so `max_landmarks` should be set to balance the delay between landmarks and the amount of state the relying party must maintain. Using the recommended procedure above, a CA with a maximum certificate lifetime of 7 days, allocating a landmark every hour, will have a `max_landmarks` of 168. The client state is then 336 hashes, or 10,752 bytes with SHA-256.
 


### PR DESCRIPTION
With the current ceil calculation, it's possible that unexpired entries could be present in a subtree that is marked inactive. Let's say we break up time into landmark intervals and allow one landmark to be added per interval. Then, say we have the following parameters:

```
time_between_landmarks: 100
max_cert_lifetime: 290
```

which determines `max_landmarks = ceil(290/100) = 3`.

We could have the following landmark intervals:

```
[0, 100), [100, 200), [200, 300), [300, 400)
```

with corresponding landmarks issued at times

```
90, 110, 210, 310
```

Then, say we have an entry issued at time `50` which expires at time `50 + 290 = 340`. It will be included in the landmark at time `90`, but that landmark will be marked inactive when the `310` landmark is added. Thus, the cert will not be unexpired but not covered by an active landmark for the interval `[310, 340)`.

Setting max_landmarks to `ceil(290/100)+1 = 4` instead ensures that we keep the `90` landmark around until at least time `400`.