### PR TITLE
Unify the two branches in the consistency proof check

### DIFF
--- a/draft-davidben-tls-merkle-tree-certs.md
+++ b/draft-davidben-tls-merkle-tree-certs.md
@@ -516,32 +516,25 @@ The following procedure can be used to verify a subtree consistency proof.
 
 Given a Merkle Tree over `n` elements, a subtree defined by `[start, end)`, a consistency proof `proof`, a subtree hash `node_hash`, and a root hash `root_hash`:
 
-1. If `end` is `n`, run the following:
-   1. Set `fn` to `start` and `sn` to `end - 1`.
-   2. Set `r` to `node_hash`.
-   3. Until `LSB(fn)` is set or `sn` is `0`, right-shift `fn` and `sn` equally.
-   4. For each value `p` in the `proof` array:
-      1. If `sn` is `0`, then stop iteration and fail the proof verification.
-      2. Set `r` to `HASH(0x01 || p || r)`.
-      3. Until `LSB(sn)` is set, right-shift `sn`.
-      4. Right-shift `sn` once more.
-   5. Compare `sn` to `0` and `r` to `root_hash`. If either is not equal, fail the proof verification. If all are equal, accept the proof.
-2. Otherwise, run the following:
+1. Set `fn` to `start`, `sn` to `end - 1`, and `tn` to `n - 1`.
+1. If `sn` is `tn`, then:
+   1. Right-shift `fn`, `sn`, and `tn` equally until `fn` is `sn`.
+1. Otherwise:
+   1. Right-shift `fn`, `sn`, and `tn` equally until `LSB(sn)` is not set or `fn` is `sn`
+1. If `fn` is `sn`, set `fr` and `sr` to `node_hash`.
+1. Otherwise:
    1. If `proof` is an empty array, stop and fail verification.
-   2. If `end - start` is an exact power of two, prepend `node_hash` to the `proof` array.
-   3. Set `fn` to `start`, `sn` to `end - 1`, and `tn` to `n - 1`.
-   4. Until `LSB(sn)` is not set or `fn` is equal to `sn`, right-shift `fn`, `sn`, and `tn` equally.
-   5. Set both `fr` and `sr` to the first value in the `proof` array.
-   6. For each subsequent value `c` in the `proof` array:
-      1. If `tn` is `0`, then stop the iteration and fail the proof verification.
-      2. If `LSB(sn)` is set, or if `sn` is equal to `tn`, then:
-         1. If `fn < sn`, set `fr` to `HASH(0x01 || c || fr)`.
-         2. Set `sr` to `HASH(0x01 || c || sr)`.
-         3. Until `LSB(sn)` is set, right-shift `fn`, `sn`, and `tn` equally.
-      3. Otherwise:
-         1. Set `sr` to `HASH(0x01 || sr || c)`.
-      4. Right-shift `fn`, `sn`, and `tn` once more.
-   7. Compare `tn` to `0`, `fr` to `node_hash`, and `sr` to `root_hash`. If any are not equal, fail the proof verification. If all are equal, accept the proof.
+   1. Remove the first value of the `proof` array and set `fr` and `sr` to the removed value.
+1. For each value `c` in the `proof` array:
+   1. If `tn` is `0`, then stop the iteration and fail the proof verification.
+   1. If `LSB(sn)` is set, or if `sn` is equal to `tn`, then:
+      1. If `fn < sn`, set `fr` to `HASH(0x01 || c || fr)`.
+      1. Set `sr` to `HASH(0x01 || c || sr)`.
+      1. Until `LSB(sn)` is set, right-shift `fn`, `sn`, and `tn` equally.
+   1. Otherwise:
+      1. Set `sr` to `HASH(0x01 || sr || c)`.
+   1. Right-shift `fn`, `sn`, and `tn` once more.
+1. Compare `tn` to `0`, `fr` to `node_hash`, and `sr` to `root_hash`. If any are not equal, fail the proof verification. If all are equal, accept the proof.
 
 ## Arbitrary Intervals
 


### PR DESCRIPTION
Also replace prepending to the proof list with removing in the other branch. It makes it a little obvious how to implement this without making a copy of the proof. This should also hopefully make the relationship between inclusion and consistency proof evaluation clearer.

While I'm here, use '1.' for the steps so we don't have to renumber it as it changes.

(CC @nharper)