### PR TITLE
charter: Avoid using "log" as both a noun and a verb in the same sentence

### DIFF
--- a/charter-ietf-plants.md
+++ b/charter-ietf-plants.md
@@ -6,7 +6,7 @@ This is a draft charter for a new IETF working group. The working group does not
 
 The goal of the PLANTS Working Group is to trim the increasing costs of operating PKIs with Certificate Transparency (CT; RFC 6962 and RFC 9162), when used in interactive protocols like TLS (RFC 8446).
 
-Today, such applications apply two separate systems: a certification authority (CA) signs individual bindings between public keys and application identifiers (e.g., a DNS name), returning an X.509 certificate. CT logs then log entire certificates, returning signed certificate timestamps. The outputs of these two steps are presented to the relying party.
+Today, such applications apply two separate systems: a certification authority (CA) signs individual bindings between public keys and application identifiers (e.g., a DNS name), returning an X.509 certificate. The CA then sends the entire certificate to a quorum of CT logs, obtaining signed certificate timestamps. The outputs of these two steps are presented to the relying party.
 
 Overhead from post-quantum signatures and keys will add significant costs in two ways:
 


### PR DESCRIPTION
Strictly speaking, if you "send" the entire certificate, the log might only retain a part of the certificate, but the subsequent paragraph clarifies that the "log entry" contains the entire certificate, so I think that's fine.

@debcooley, how's this look?