### PR TITLE
Add randomizer to leafs

### DIFF
--- a/demo/config.go
+++ b/demo/config.go
@@ -23,6 +23,7 @@ const (
 	VersionDavidben10
 	VersionPlants01
 	VersionPlants02
+	VersionPlants04
 )
 
 func (v DraftVersion) String() string {
@@ -35,6 +36,8 @@ func (v DraftVersion) String() string {
 		return "plants-01"
 	case VersionPlants02:
 		return "plants-02"
+	case VersionPlants04:
+		return "plants-04"
 	}
 	panic(fmt.Sprintf("unknown version %d", v))
 }
@@ -62,6 +65,8 @@ func DraftVersionFromString(s string) (v DraftVersion, ok bool) {
 		return VersionPlants01, true
 	case "plants-02":
 		return VersionPlants02, true
+	case "plants-04":
+		return VersionPlants04, true
 
 	default:
 		return 0, false

--- a/demo/config.go
+++ b/demo/config.go
@@ -66,6 +66,10 @@ func DraftVersionFromString(s string) (v DraftVersion, ok bool) {
 	case "plants-02":
 		return VersionPlants02, true
 	case "plants-04":
+		// TODO: not fully up-to-date with draft-04 yet. Still missing:
+		//   - CA cosigner's ID should now be the log ID (fix in provided config file).
+		//   - Signature scheme has been updated.
+		//   - Add code to synthesize the CA certs.
 		return VersionPlants04, true
 
 	default:

--- a/demo/encode.go
+++ b/demo/encode.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
+	"fmt"
 	"math/bits"
 	"time"
 
@@ -190,11 +191,26 @@ func AddTBSCertificate(b *cryptobyte.Builder, issuer TrustAnchorID, serial int, 
 	})
 }
 
-func MarshalNullEntry() []byte {
-	return []byte{byte(entryTypeNull >> 8), byte(entryTypeNull)}
+// MarshalNullEntry returns the encoding of a null MerkleTreeCertEntry. For
+// draft-plants-04 and later, this is prefixed with the 32-byte randomizer.
+func MarshalNullEntry(version DraftVersion, randomizer []byte) ([]byte, error) {
+	b := cryptobyte.NewBuilder(nil)
+	if version >= VersionPlants04 {
+		if len(randomizer) != randomizerSize {
+			return nil, fmt.Errorf("randomizer must be %d bytes, got %d", randomizerSize, len(randomizer))
+		}
+		b.AddBytes(randomizer)
+	}
+	b.AddUint16(entryTypeNull)
+	return b.Bytes()
 }
 
-func MarshalTBSCertificateLogEntry(version DraftVersion, issuer TrustAnchorID, entry *EntryConfig) ([]byte, error) {
+const randomizerSize = 32
+
+// MarshalTBSCertificateLogEntry returns the encoding of a tbs_cert_entry
+// MerkleTreeCertEntry. For draft-plants-04 and later, the encoding is prefixed
+// with the 32-byte randomizer.
+func MarshalTBSCertificateLogEntry(version DraftVersion, issuer TrustAnchorID, randomizer []byte, entry *EntryConfig) ([]byte, error) {
 	marshalContents := func(tbs *cryptobyte.Builder) {
 		addX509V3Version(tbs)
 		addIssuer(tbs, issuer)
@@ -220,6 +236,14 @@ func MarshalTBSCertificateLogEntry(version DraftVersion, issuer TrustAnchorID, e
 		addExtensions(tbs, entry)
 	}
 	b := cryptobyte.NewBuilder(nil)
+	// Starting draft-plants-04, MerkleTreeCertEntry is prefixed with a
+	// 32-byte randomizer.
+	if version >= VersionPlants04 {
+		if len(randomizer) != randomizerSize {
+			return nil, fmt.Errorf("randomizer must be %d bytes, got %d", randomizerSize, len(randomizer))
+		}
+		b.AddBytes(randomizer)
+	}
 	b.AddUint16(entryTypeTBSCert)
 	// Starting draft-davidben-10, the SEQUENCE wrapper is omitted.
 	if version >= VersionDavidben10 {
@@ -230,7 +254,7 @@ func MarshalTBSCertificateLogEntry(version DraftVersion, issuer TrustAnchorID, e
 	return b.Bytes()
 }
 
-func CreateCertificate(issuanceLog *MerkleTree, issuer TrustAnchorID, cosigners []*CosignerConfig, entry *EntryConfig, certConfig *CertificateConfig, index, start, end int) ([]byte, error) {
+func CreateCertificate(version DraftVersion, issuanceLog *MerkleTree, issuer TrustAnchorID, cosigners []*CosignerConfig, entry *EntryConfig, certConfig *CertificateConfig, randomizer []byte, index, start, end int) ([]byte, error) {
 	b := cryptobyte.NewBuilder(nil)
 	b.AddASN1(cbasn1.SEQUENCE, func(cert *cryptobyte.Builder) {
 		AddTBSCertificate(cert, issuer, index, entry)
@@ -258,6 +282,15 @@ func CreateCertificate(issuanceLog *MerkleTree, issuer TrustAnchorID, cosigners 
 				certSig.AddBytes([]byte{1})
 			} else {
 				certSig.AddBytes([]byte{0})
+			}
+			// Starting draft-plants-04, MTCProof is prefixed with the
+			// 32-byte randomizer of the corresponding MerkleTreeCertEntry.
+			if version >= VersionPlants04 {
+				if len(randomizer) != randomizerSize {
+					certSig.SetError(fmt.Errorf("randomizer must be %d bytes, got %d", randomizerSize, len(randomizer)))
+					return
+				}
+				certSig.AddBytes(randomizer)
 			}
 			certSig.AddUint64(uint64(start))
 			certSig.AddUint64(uint64(end))

--- a/demo/encode_test.go
+++ b/demo/encode_test.go
@@ -27,11 +27,19 @@ func TestMarshalTBSCertificate(t *testing.T) {
 		0x94, 0x2d, 0x4b, 0xcf, 0x72, 0x22, 0xc1,
 	}
 
+	// 32-byte fixed randomizer used for deterministic plants-04 test
+	// vectors. Encoded as "00010203...1f".
+	fixedRandomizer := make([]byte, 32)
+	for i := range fixedRandomizer {
+		fixedRandomizer[i] = byte(i)
+	}
+
 	var tests = []struct {
 		version             DraftVersion
 		issuer              TrustAnchorID
 		serial              int
 		entry               *EntryConfig
+		randomizer          []byte
 		expectedTBSHex      string
 		expectedLogEntryHex string
 	}{
@@ -47,6 +55,21 @@ func TestMarshalTBSCertificate(t *testing.T) {
 			},
 			expectedTBSHex:      "3081afa003020102020204d2300c060a2b0601040182da4b2f00301931173015060a2b0601040182da4b2f010c0733323437332e31301e170d3230303130313030303030305a170d3230313233313233353935395a30003059301306072a8648ce3d020106082a8648ce3d03010703420004e62b69e2bf659f97be2f1e0d948a4cd5976bb7a91e0d46fbdda9a91e9ddcba5a01e7d697a80a18f9c3c4a31e56e27c8348db161a1cf51d7ef1942d4bcf7222c1",
 			expectedLogEntryHex: "0001a003020102301931173015060a2b0601040182da4b2f010c0733323437332e31301e170d3230303130313030303030305a170d3230313233313233353935395a3000301306072a8648ce3d020106082a8648ce3d0301070420b3aea0f0a50538874f2b4c912f2676bd25ccc3dae700e20dcad42d3d5c074ca5",
+		},
+		// draft-plants-04 prefixes the MerkleTreeCertEntry with a 32-byte
+		// randomizer. The TBSCertificate itself is unchanged.
+		{
+			version: VersionPlants04,
+			issuer:  issuer,
+			serial:  1234,
+			entry: &EntryConfig{
+				PublicKey: publicKey,
+				NotBefore: time.Unix(1577836800, 0), // 2020-01-01 00:00:00
+				NotAfter:  time.Unix(1609459199, 0), // 2020-12-31 23:59:59
+			},
+			randomizer:          fixedRandomizer,
+			expectedTBSHex:      "3081afa003020102020204d2300c060a2b0601040182da4b2f00301931173015060a2b0601040182da4b2f010c0733323437332e31301e170d3230303130313030303030305a170d3230313233313233353935395a30003059301306072a8648ce3d020106082a8648ce3d03010703420004e62b69e2bf659f97be2f1e0d948a4cd5976bb7a91e0d46fbdda9a91e9ddcba5a01e7d697a80a18f9c3c4a31e56e27c8348db161a1cf51d7ef1942d4bcf7222c1",
+			expectedLogEntryHex: hex.EncodeToString(fixedRandomizer) + "0001a003020102301931173015060a2b0601040182da4b2f010c0733323437332e31301e170d3230303130313030303030305a170d3230313233313233353935395a3000301306072a8648ce3d020106082a8648ce3d0301070420b3aea0f0a50538874f2b4c912f2676bd25ccc3dae700e20dcad42d3d5c074ca5",
 		},
 		// Fill in a bit of everything.
 		{
@@ -124,7 +147,7 @@ func TestMarshalTBSCertificate(t *testing.T) {
 			t.Errorf("%d. AddTBSCertificate() gave %s, wanted %s", i, got, tt.expectedTBSHex)
 		}
 
-		log, err := MarshalTBSCertificateLogEntry(tt.version, tt.issuer, tt.entry)
+		log, err := MarshalTBSCertificateLogEntry(tt.version, tt.issuer, tt.randomizer, tt.entry)
 		if err != nil {
 			t.Errorf("%d. MarshalTBSCertificateLogEntry() failed: %s", i, err)
 		} else if got := hex.EncodeToString(log); got != tt.expectedLogEntryHex {

--- a/demo/main.go
+++ b/demo/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
 	"flag"
@@ -65,6 +66,19 @@ func tlogCheckpointKeyID(id TrustAnchorID) [4]byte {
 	return *(*[4]byte)(h[:])
 }
 
+// demoRandomizer returns SHA-256(index) for draft-plants-04 and later, or 32
+// zero bytes otherwise. A real CA would use a CSPRNG; the demo derives the
+// randomizer deterministically for reproducibility.
+func demoRandomizer(version DraftVersion, index int) []byte {
+	if version < VersionPlants04 {
+		return make([]byte, 32)
+	}
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(index))
+	h := sha256.Sum256(buf[:])
+	return h[:]
+}
+
 func do() error {
 	// Load the config.
 	configBytes, err := os.ReadFile(*flagConfig)
@@ -76,8 +90,15 @@ func do() error {
 		return err
 	}
 
+	// The demo derives the per-entry randomizer (draft-plants-04 and later)
+	// deterministically from the entry index using demoRandomizer. A real CA
+	// would use a CSPRNG.
+	nullEntry, err := MarshalNullEntry(config.Version, demoRandomizer(config.Version, 0))
+	if err != nil {
+		return err
+	}
 	// Entries in the issuance log.
-	entries := [][]byte{MarshalNullEntry()}
+	entries := [][]byte{nullEntry}
 	// Certificates to be constructed.
 	var certInfos []certificateInfo
 	// Maps checkpoint sequence name to a list of certInfos indices that are
@@ -99,7 +120,7 @@ func do() error {
 			repeat = entryConfig.Repeat
 		}
 		for range repeat {
-			entry, err := MarshalTBSCertificateLogEntry(config.Version, config.LogID, entryConfig)
+			entry, err := MarshalTBSCertificateLogEntry(config.Version, config.LogID, demoRandomizer(config.Version, len(entries)), entryConfig)
 			if err != nil {
 				return err
 			}
@@ -178,7 +199,7 @@ func do() error {
 		// certificate. Rather it cosign subtrees as it checkpoints. This tool
 		// is less opinionated about subtrees, so we would need to make a
 		// cosignature cache to simulate this.
-		cert, err := CreateCertificate(issuanceLog, config.LogID, info.cosigners, info.entryConfig, info.certConfig, info.index, info.start, info.end)
+		cert, err := CreateCertificate(config.Version, issuanceLog, config.LogID, info.cosigners, info.entryConfig, info.certConfig, demoRandomizer(config.Version, info.index), info.index, info.start, info.end)
 		if err != nil {
 			return err
 		}

--- a/demo/mtc.json
+++ b/demo/mtc.json
@@ -1,5 +1,5 @@
 {
-  "Version": "plants-02",
+  "Version": "plants-04",
   "LogID": "32473.1",
   "Cosigners": [
     {

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1693,13 +1693,13 @@ A key security requirement of any PKI scheme is that relying parties only accept
 
 * In landmark-relative certificates, the cosigner requirements are checked ahead of time, when the trusted subtrees are predistributed ({{trusted-subtrees}}).
 
-Given a subtree hash computed over entries that the CA certified, it must be computationally infeasible to construct an entry not on this list, and an inclusion proof, such that inclusion proof verification succeeds. A colission-resistant hash is sufficient, but not required: it's also enough for the hash to be multi-target second-preimage resistant. A secure 256-bit hash provides 256-t multi-target second-preimage resistance against 2^t targets, and thus 200-bit authenticity for a log of 2^55 entries.
+Given a subtree hash computed over entries that the CA certified, it must be computationally infeasible to construct an entry not on this list, and an inclusion proof, such that inclusion proof verification succeeds. A collision-resistant hash is sufficient, but not required: it's also enough for the hash to be multi-target second-preimage resistant. A secure 256-bit hash provides 256-t multi-target second-preimage resistance against 2^t targets, and thus 200-bit authenticity for a log of 2^55 entries.
 
-The previous assumes the attacker does not influence which entries are certified. In normal operation, an attacker can request legitimate issuance of entries. An attacker might find two entries with the same hash, and request issuance for one, leading to a certification of the second. The `randomizer` thwarts this.
+The previous assumes the attacker does not influence which entries are certified. In normal operation, an attacker can request legitimate issuance of entries, e.g. certificates for DNS names the attacker controls. An attacker might find two entries with the same hash, one of which of it is authorized to request. It might than request issuance for the authortized entry, leading to a certification of the other entry. The `randomizer` thwarts this.
 
 Log entries contain public key hashes. It must additionally be computationally infeasible to compute a public key whose hash matches an existing entry, other than the intended public key. This is again second-preimage multitarget resistance.
 
-The subject public key hash is not randomized, and so an attacker that is able to compute colissions could find two subject public keys with the same hash, which is of no security concern given the attacker needs permission to publish either anyway.
+The subject public key hash is not randomized, and so an attacker that is able to compute collisions could find two subject public keys with the same hash. However, in order to request certification of a new entry with this hash, the attacker must already be authorized for this new entry. The attacker would thus only be able to certify colliding pairs of public keys for its own identities.
 
 ## Public Key Hashes
 

--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -945,6 +945,7 @@ enum {
 } MerkleTreeCertEntryType;
 
 struct {
+    opaque randomizer[32];
     MerkleTreeCertEntryType type;
     select (type) {
        case null_entry: Empty;
@@ -957,6 +958,8 @@ struct {
 When `type` is `null_entry`, the entry does not represent any information. The entry at index zero of every issuance log MUST be of type `null_entry`. This avoids zero serial numbers in the certificate format ({{certificate-format}}). Other entries MAY have type `null_entry`.
 
 When `type` is `tbs_cert_entry`, `N` is the number of bytes needed to consume the rest of the input. A MerkleTreeCertEntry is expected to be decoded in contexts where the total length of the entry is known.
+
+`randomizer` are 32 bytes chosen by the CA to make the hash of the entry unpredictable, and with it increase forgery resistance, see {{authenticity}}.
 
 `tbs_cert_entry_data` contains the contents octets (i.e. excluding the initial identifier and length octets) of the DER {{X.690}} encoding of a TBSCertificateLogEntry, defined below. Equivalently, `tbs_cert_entry_data` contains the DER encodings of each field of the TBSCertificateLogEntry, concatenated. This construction allows a single-pass implementation in {{verifying-certificate-signatures}}.
 
@@ -1213,6 +1216,7 @@ struct {
 } MTCSignature;
 
 struct {
+    opaque randomizer[32];
     uint64 start;
     uint64 end;
     HashValue inclusion_proof<0..2^16-1>;
@@ -1220,7 +1224,7 @@ struct {
 } MTCProof;
 ~~~
 
-`start` and `end` MUST contain the corresponding parameters of the chosen subtree. `inclusion_proof` MUST contain a subtree inclusion proof ({{subtree-inclusion-proofs}}) for the log entry and the subtree. `signatures` contains the chosen subtree signatures. In each signature, `cosigner_id` contains the cosigner ID ({{cosigners}}) in its binary representation ({{Section 3 of !I-D.ietf-tls-trust-anchor-ids}}), and `signature` contains the signature value as described in {{signature-format}}. The `timestamp` field used when computing the signature MUST be zero.
+`randomizer` MUST contain the value of the corresponding field of the MerkleTreeCertEntry ({{log-entries}}). `start` and `end` MUST contain the corresponding parameters of the chosen subtree. `inclusion_proof` MUST contain a subtree inclusion proof ({{subtree-inclusion-proofs}}) for the log entry and the subtree. `signatures` contains the chosen subtree signatures. In each signature, `cosigner_id` contains the cosigner ID ({{cosigners}}) in its binary representation ({{Section 3 of !I-D.ietf-tls-trust-anchor-ids}}), and `signature` contains the signature value as described in {{signature-format}}. The `timestamp` field used when computing the signature MUST be zero.
 
 The MTCProof is encoded into the `signatureValue` with no additional ASN.1 wrapping. The most significant bit of the first octet of the signature value SHALL become the first bit of the bit string, and so on through the least significant bit of the last octet of the signature value, which SHALL become the last bit of the bit string.
 
@@ -1413,7 +1417,7 @@ When verifying the signature of an X.509 certificate (Step (a)(1) of {{Section 6
    1. Set `subjectPublicKeyAlgorithm` to the `algorithm` field of the `subjectPublicKeyInfo`.
    1. Set `subjectPublicKeyInfoHash` to the hash of the DER encoding of `subjectPublicKeyInfo`.
 
-1. Construct a MerkleTreeCertEntry of type `tbs_cert_entry` with contents the TBSCertificateLogEntry. Let `entry_hash` be the hash of the entry, `MTH({entry}) = HASH(0x00 || entry)`, as defined in {{Section 2.1.1 of !RFC9162}}.
+1. Construct a MerkleTreeCertEntry of type `tbs_cert_entry` with `randomizer` taken from the MTCProof and contents the TBSCertificateLogEntry. Let `entry_hash` be the hash of the entry, `MTH({entry}) = HASH(0x00 || entry)`, as defined in {{Section 2.1.1 of !RFC9162}}.
 
 1. Let `expected_subtree_hash` be the result of evaluating the MTCProof's `inclusion_proof` for entry `index`, with hash `entry_hash`, of the subtree described by the MTCProof's `start` and `end`, following the procedure in {{evaluating-a-subtree-inclusion-proof}}. If evaluation fails, abort this process and fail verification.
 
@@ -1426,6 +1430,7 @@ This procedure only replaces the signature verification portion of X.509 path va
 In this procedure, `entry_hash` can equivalently be computed in a single pass from the DER-encoded TBSCertificate, without storing the full TBSCertificateLogEntry or MerkleTreeCertEntry in memory:
 
 1. Initialize a hash instance.
+1. Write the 32-byte `randomizer` from the MTCProof to the hash.
 1. Write the big-endian, two-byte `tbs_cert_entry` value to the hash.
 1. Write the TBSCertificate contents octets to the hash, up to the `subjectPublicKeyInfo` field.
 1. Write the `subjectPublicKeyInfo`'s `algorithm` field to the hash.
@@ -1666,18 +1671,6 @@ In particular, relying parties that share an update process for trusted subtrees
 
 # Security Considerations
 
-## Authenticity
-
-A key security requirement of any PKI scheme is that relying parties only accept assertions that were certified by a trusted certification authority. Merkle Tree certificates achieve this by ensuring the relying party only accepts authentic subtree hashes:
-
-* In standalone certificates, the relying party's cosigner requirements ({{trusted-cosigners}}) are expected to include some signature by the CA's cosigner. The CA's cosigner ({{certification-authority-cosigners}}) is defined to certify the contents of every checkpoint and subtree that it signs.
-
-* In landmark-relative certificates, the cosigner requirements are checked ahead of time, when the trusted subtrees are predistributed ({{trusted-subtrees}}).
-
-Given a subtree hash computed over entries that the CA certified, it must be computationally infeasible to construct an entry not on this list, and an inclusion proof, such that inclusion proof verification succeeds. This requires using a collision-resistant hash in the Merkle Tree construction.
-
-Log entries contain public key hashes. It must additionally be computationally infeasible to compute a public key whose hash matches the entry, other than the intended public key. This also requires a collision-resistant hash.
-
 ## Transparency
 
 The transparency mechanisms in this document do not prevent a CA from issuing an unauthorized certificate. Rather, they provide comparable security properties as Certificate Transparency {{?RFC9162}} in ensuring that all certificates are either rejected by relying parties, or visible to monitors and, in particular, the subject of the certificate.
@@ -1689,6 +1682,24 @@ A CA might violate the append-only property of its log and present different vie
 If the CA sends one view to some cosigners and another view to other cosigners, it is possible that multiple views will be accepted by relying parties. However, in that case monitors will observe that cosigners do not match each other. Relying parties can then react by revoking the inconsistent indices ({{revocation-by-index}}), and likely removing the CA. If the cosigners are mirrors, the underlying entries in both views will also be visible.
 
 A CA might correctly construct its log, but refuse to serve some unauthorized entry, e.g. by feigning an outage or pruning the log outside the retention policy ({{log-availability}}). If the relying party requires cosignatures from trusted mirrors, the entry will either be visible to monitors in the mirrors, or have never reached a mirror. In the latter case, the entry will not have been cosigned, so the relying party would not accept it. If the relying party accepts log views without a trusted mirror, the unauthorized entry may not be available. However, the existence of _some_ entry at that index will be visible, so monitors will know the CA is failing to present an entry. Relying parties can then react by revoking the undisclosed entries by index ({{revocation-by-index}}), and likely removing the CA.
+
+The transparency guarantee of the system depends crucially on the collision resistance of the hash. If a CA can construct two different entries with the same hash, it can publish the benign once while keeping a malicious one hidden. A secure 256-bit hash provides 128-bit colission resistance.
+
+## Authenticity {#authenticity}
+
+A key security requirement of any PKI scheme is that relying parties only accept assertions that were certified by a trusted certification authority. Merkle Tree certificates achieve this by ensuring the relying party only accepts authentic subtree hashes:
+
+* In standalone certificates, the relying party's cosigner requirements ({{trusted-cosigners}}) are expected to include some signature by the CA's cosigner. The CA's cosigner ({{certification-authority-cosigners}}) is defined to certify the contents of every checkpoint and subtree that it signs.
+
+* In landmark-relative certificates, the cosigner requirements are checked ahead of time, when the trusted subtrees are predistributed ({{trusted-subtrees}}).
+
+Given a subtree hash computed over entries that the CA certified, it must be computationally infeasible to construct an entry not on this list, and an inclusion proof, such that inclusion proof verification succeeds. A colission-resistant hash is sufficient, but not required: it's also enough for the hash to be multi-target second-preimage resistant. A secure 256-bit hash provides 256-t multi-target second-preimage resistance against 2^t targets, and thus 200-bit authenticity for a log of 2^55 entries.
+
+The previous assumes the attacker does not influence which entries are certified. In normal operation, an attacker can request legitimate issuance of entries. An attacker might find two entries with the same hash, and request issuance for one, leading to a certification of the second. The `randomizer` thwarts this.
+
+Log entries contain public key hashes. It must additionally be computationally infeasible to compute a public key whose hash matches an existing entry, other than the intended public key. This is again second-preimage multitarget resistance.
+
+The subject public key hash is not randomized, and so an attacker that is able to compute colissions could find two subject public keys with the same hash, which is of no security concern given the attacker needs permission to publish either anyway.
 
 ## Public Key Hashes
 


### PR DESCRIPTION
MTC provides 128-bit security for its transparency goals: a CA needs to find a SHA-256 colission to hide a certificate from monitors.

Before this commit, an outside attacker can do something similar: find a hash colission to get a benign and malicious entry with the same hash. The attacker would then ask the CA to publish the benign entry with which it'll also get the malicious one certified. Thus forgery resistance is also capped at 128 bit.

This commit adds a CA-chosen randomizer to each leaf. This does not change transparency security: that's still 128-bit, but it does bump the forgery resistance to at least the multi-target second-preimage resistance of the hash. So that's 192+ bits with less than 2^63 leafs in the tree.