### PR TITLE
Expand on how to fill in the CosignedMessage

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1439,7 +1439,15 @@ When verifying the signature of an X.509 certificate (Step (a)(1) of {{Section 6
 
 1. If `log_number`, `start`, and `end` matches a trusted subtree ({{trusted-subtrees}}) for the CA, check that `expected_subtree_hash` is equal to the trusted subtree's hash. Return success if it matches and failure if it does not.
 
-1. Otherwise, check that the MTCProof's `signatures` contain a sufficient set of valid signatures from cosigners to satisfy the relying party's cosigner requirements ({{trusted-cosigners}}). Unrecognized cosigners MUST be ignored. Signatures are verified as described in {{signature-format}}. Reconstruct the CosignedMessage from MTCProof's `start` and `end`, the cosigner ID for `cosigner_name`, `log_id` for `log_origin`, `expected_subtree_hash` for `subtree_hash`, and `timestamp` set to zero.
+1. Otherwise, check that the MTCProof's `signatures` contain a sufficient set of valid signatures from cosigners to satisfy the relying party's cosigner requirements ({{trusted-cosigners}}). Unrecognized cosigners MUST be ignored.
+
+   Signatures are verified as described in {{signature-format}}. For each signature verification, the CosignedMessage structure is constructed as follows:
+
+   1. Set the CosignedMessage's `cosigner_name` based on the cosigner ID as described in {{signature-format}}.
+   1. Set the CosignedMessage's `timestamp` to zero.
+   1. Set the CosignedMessage's `log_origin` based on `log_id` as described in {{signature-format}}.
+   1. Set the CosignedMessage's `start` and `end` to the MTCProof's `start` and `end`, respectively.
+   1. Set the CosignedMessage's `subtree_hash` to `expected_subtree_hash`.
 
 This procedure only replaces the signature verification portion of X.509 path validation. The relying party MUST continue to perform other checks, such as checking expiry.
 


### PR DESCRIPTION
It was getting a bit wordy, especially now that we actually need to do some transforms to go from ID to tlog-style name.