### PR TITLE
Clarify that leftover bits or bytes are invalid

### DIFF
--- a/draft-ietf-plants-merkle-tree-certs.md
+++ b/draft-ietf-plants-merkle-tree-certs.md
@@ -1443,7 +1443,7 @@ When verifying the signature of an X.509 certificate (Step (a)(1) of {{Section 6
 
 1. Check that the TBSCertificate's `signature` field is `id-alg-mtcProof` with omitted parameters. If this check fails, abort this process and fail verification.
 
-1. Decode the `signatureValue` as an MTCProof, as described in {{certificate-format}}.
+1. Decode the `signatureValue` as an MTCProof, as described in {{certificate-format}}. If decoding fails, including if `signatureValue` is not a multiple of 8 bits or has extra data after the MTCProof, abort this process and fail verification.
 
 1. Let `serial` be the certificate's serial number. If `serial` is negative or greater than 2<sup>64</sup>-1, abort this process and fail verification.
 


### PR DESCRIPTION
This is implied by the definition of the format:

> The MTCProof is encoded into the signatureValue with no additional
> ASN.1 wrapping. The most significant bit of the first octet of the
> signature value SHALL become the first bit of the bit string, and so
> on through the least significant bit of the last octet of the
> signature value, which SHALL become the last bit of the bit string.

But it's tripped a couple folks already, so let's be explicit about it.

This is a tax that every use of X.509 must pay. Cryptography is built on bytes, and X.509 foolishly used BIT STRINGs everywhere.