### PR TITLE
demo: fix UnusedBit panic on signing error

### DIFF
--- a/demo/encode.go
+++ b/demo/encode.go
@@ -406,7 +406,7 @@ func CreateCertificate(config *CAConfig, issuanceLog *MerkleTree, cosigners []*C
 				}
 			})
 			if certConfig.UnusedBit {
-				if sig, err := certSig.Bytes(); err == nil && len(sig) == 0 || sig[len(sig)-1]&1 != 0 {
+				if sig, err := certSig.Bytes(); err == nil && (len(sig) == 0 || sig[len(sig)-1]&1 != 0) {
 					certSig.SetError(errors.New("last bit in signature with not zero, unable to encode as unused"))
 					return
 				}


### PR DESCRIPTION
Fixes an operator-precedence bug in CreateCertificate's UnusedBit handling.

&& binds tighter than ||, so sig[len(sig)-1] could be evaluated even when certSig.Bytes() returned an error. Add parentheses so the signature bytes are only inspected when Bytes() succeeds.

Tested:

go test ./...
